### PR TITLE
 fix(opencode): не копировать tools/allowedTools массивом — OpenCode требует object

### DIFF
--- a/adapters/opencode.yaml
+++ b/adapters/opencode.yaml
@@ -9,6 +9,11 @@
 #   - OpenCode distinguishes primary agents from subagents via a `mode` field.
 #     We set `mode: subagent` when source has `isSubagent: true`,
 #     and `mode: primary` otherwise, via `frontmatter.addIf`.
+#   - OpenCode expects agent/command `tools` as an OBJECT ({read: true, ...}),
+#     not an array. content/ stores tools as a YAML list (right for Cursor /
+#     Claude Code), so we DROP `tools` here — an array fails OpenCode config
+#     validation and blocks the whole config. Dropped agents/commands fall back
+#     to OpenCode's default tool set.
 #   - OpenCode natively reads skills from `.claude/skills/` (besides its own
 #     `.opencode/skills/`). To avoid duplicate skill folders, we write skills
 #     to `.claude/skills/` — shared with Claude Code when both are installed.
@@ -34,21 +39,19 @@ rules:
 agents:
   copyTo: ".opencode/agent/{name}.md"
   frontmatter:
-    keep: [name, description, tools, modelHint]
+    keep: [name, description, modelHint]
     rename:
       modelHint: model
     addIf:
       isSubagent: { mode: subagent }
       "!isSubagent": { mode: primary }
-    drop: [isSubagent, allowParallel, reasoningEffort]
+    drop: [isSubagent, allowParallel, reasoningEffort, tools]
 
 commands:
   copyTo: ".opencode/command/{name}.md"
   frontmatter:
-    keep: [description, allowedTools]
-    rename:
-      allowedTools: tools
-    drop: [argumentHint]
+    keep: [description]
+    drop: [argumentHint, allowedTools]
 
 skills:
   copyTo: ".claude/skills/{name}/"


### PR DESCRIPTION
…ребует object

OpenCode (проверено на 1.15.10) валидирует frontmatter агентов и команд и ожидает поле `tools` как объект (`{read: true, write: false, ...}`), а не массив. Файлы в `content/agents/*.md` и `content/commands/*.md` хранят `tools` / `allowedTools` списком — это корректно для Cursor и Claude Code, но adapter opencode копировал список как есть.

В результате OpenCode при старте падает с `Configuration is invalid at .opencode/agent/<name>.md` (Expected object | undefined, got [...]) и **не загружает весь конфиг целиком** — ни MCP-серверы, ни агентов.

Фикс в adapters/opencode.yaml:
- agents: `tools` убран из `keep` (и добавлен в `drop`);
- commands: убран rename `allowedTools -> tools`, `allowedTools` в `drop`.

Агенты и команды OpenCode теперь устанавливаются без явного `tools` и используют набор инструментов OpenCode по умолчанию. Проверено: после фикса `opencode mcp list` загружается и MCP-серверы переходят в connected.

Изменение читается обоими каналами установки (install.ps1 через Invoke-FrontmatterOps и agent-driven), отдельной правки install.ps1 не нужно.