### PR TITLE
fix(md-to-docx): restart numbering per list, fit tall images, add --justify

### DIFF
--- a/content/skills/md-to-docx/SKILL.md
+++ b/content/skills/md-to-docx/SKILL.md
@@ -10,7 +10,7 @@ Converts a Markdown file to a Word document (`.docx`) preserving headings, table
 ## Usage
 
 ```
-/md-to-docx <input.md> [output.docx] [--author "Name"] [--title "Title"] [--no-shading]
+/md-to-docx <input.md> [output.docx] [--author "Name"] [--title "Title"] [--no-shading] [--justify]
 ```
 
 | Parameter | Required | Description |
@@ -20,8 +20,9 @@ Converts a Markdown file to a Word document (`.docx`) preserving headings, table
 | `--author` | no | Document author. Written to core properties (`dc:creator` + `cp:lastModifiedBy`). Also accepts the `--author=Name` form |
 | `--title` | no | Document title in core properties and in the header. Default: input file name without extension |
 | `--no-shading` | no | Disables the grey background for inline `code` and fenced ``` code blocks. Alias: `--shading=off`. On by default. Does not affect the table header (it keeps its structural fill) |
+| `--justify` | no | Justified alignment for body paragraphs and list items. Alias: `--align=justify`. Off by default; headings and table cells always stay left-aligned |
 
-If the path is not provided — ask the user. The `--author`, `--title`, `--no-shading` flags are optional — pass them only when the user explicitly asks for an author, a custom title, or removal of code shading.
+If the path is not provided — ask the user. The `--author`, `--title`, `--no-shading`, `--justify` flags are optional — pass them only when the user explicitly asks for an author, a custom title, removal of code shading, or justified text.
 
 ## Dependencies
 
@@ -43,6 +44,9 @@ node "<skill-dir>/scripts/md_to_docx.js" "<input.md>" "[output.docx]" --author "
 
 # Without the grey code background
 node "<skill-dir>/scripts/md_to_docx.js" "<input.md>" "[output.docx]" --no-shading
+
+# With justified body text
+node "<skill-dir>/scripts/md_to_docx.js" "<input.md>" "[output.docx]" --justify
 ```
 
 Bash (macOS / Linux):
@@ -57,10 +61,10 @@ node "<skill-dir>/scripts/md_to_docx.js" "<input.md>" "[output.docx]"
 - Headings (H1–H6) with styles and colors
 - Tables with header row
 - Code blocks (monospace font, gray background)
-- Lists: bulleted and numbered (with nesting)
+- Lists: bulleted and numbered (with nesting). Every numbered list is numbered independently and starts at the ordinal written in the markdown — a list opening with `4.` renders as `4.`
 - Inline formatting: **bold**, *italic*, `code`, [links](url)
 - Internal anchor links: `<a id="name"></a>` before a heading becomes a bookmark; `[text](#name)` links resolve to it (external `http(s)` / `mailto:` links stay external)
-- Images (`![alt](path)`) — resolved relative to the source MD folder
+- Images (`![alt](path)`) — resolved relative to the source MD folder; scaled down to fit both the content width and the printable page height
 - Horizontal rules (`---`)
 - Headers/footers: title in the top, page number in the bottom
 - Core properties: author and title (via `--author` / `--title`)

--- a/content/skills/md-to-docx/scripts/md_to_docx.js
+++ b/content/skills/md-to-docx/scripts/md_to_docx.js
@@ -5,7 +5,7 @@
  * Usage:
  *   node md_to_docx.js input.md [output.docx] \
  *       [--author "Author Name"] [--title "Document Title"] \
- *       [--no-shading | --shading=on|off]
+ *       [--no-shading | --shading=on|off] [--justify]
  *
  *   - Output is optional; if omitted, replaces .md with .docx next to input.
  *   - --author writes core property dc:creator and cp:lastModifiedBy.
@@ -13,6 +13,9 @@
  *   - --no-shading (alias: --shading=off) disables grey background fill
  *     for inline `code` and fenced ``` code blocks. Table header shading
  *     is structural and is NOT affected by this flag.
+ *   - --justify (alias: --align=justify) sets justified alignment for body
+ *     paragraphs and list items. Headings and table cells stay left-aligned.
+ *     Off by default.
  *   - Both --flag value and --flag=value forms are supported.
  *
  * Requires: npm ci in the skill directory (package-lock.json pins docx).
@@ -34,6 +37,7 @@ const positional = [];
 let author = null;
 let titleOverride = null;
 let codeShading = true;
+let justify = false;
 for (let k = 0; k < rawArgs.length; k++) {
   const a = rawArgs[k];
   if (a === "--author") {
@@ -50,13 +54,17 @@ for (let k = 0; k < rawArgs.length; k++) {
     codeShading = (rawArgs[++k] || "").toLowerCase() !== "off";
   } else if (a.startsWith("--shading=")) {
     codeShading = a.slice("--shading=".length).toLowerCase() !== "off";
+  } else if (a === "--justify") {
+    justify = true;
+  } else if (a.startsWith("--align=")) {
+    justify = a.slice("--align=".length).toLowerCase() === "justify";
   } else {
     positional.push(a);
   }
 }
 const inputPath = positional[0];
 if (!inputPath) {
-  console.error('Usage: node md_to_docx.js input.md [output.docx] [--author "Author Name"] [--title "Document Title"] [--no-shading]');
+  console.error('Usage: node md_to_docx.js input.md [output.docx] [--author "Author Name"] [--title "Document Title"] [--no-shading] [--justify]');
   process.exit(1);
 }
 const outputPath = positional[1] || inputPath.replace(/\.md$/i, ".docx");
@@ -173,7 +181,7 @@ while (i < lines.length) {
   const numMatch = line.match(/^(\s*)\d+\.\s+(.*)/);
   if (numMatch) {
     const indent = Math.floor((numMatch[1] || "").length / 2);
-    blocks.push({ type: "numbered", indent, text: numMatch[2] });
+    blocks.push({ type: "numbered", indent, text: numMatch[2], num: parseInt(line.trim(), 10) });
     i++;
     continue;
   }
@@ -302,6 +310,13 @@ function tryLoadImage(src) {
     width = maxWidth;
     height = Math.round(height * scale);
   }
+  // Printable height of an 11in page with 1in margins, less room for the caption
+  const maxHeight = 780;
+  if (height > maxHeight) {
+    const vScale = maxHeight / height;
+    height = maxHeight;
+    width = Math.round(width * vScale);
+  }
   return { data, type, width, height };
 }
 
@@ -317,8 +332,28 @@ const cellBorders = { top: border, bottom: border, left: border, right: border }
 const PAGE_WIDTH = 12240; // US Letter
 const MARGIN = 1440; // 1 inch
 const CONTENT_WIDTH = PAGE_WIDTH - 2 * MARGIN; // 9360
+const bodyAlignment = justify ? AlignmentType.JUSTIFIED : undefined;
+
+// Each numbered list gets its own numbering reference, starting at the ordinal
+// written in the markdown. A single shared reference would number every list in
+// the document continuously.
+const numberLists = [];
+let curNumList = null;
+function numberingRefFor(block) {
+  const n = Number.isFinite(block.num) ? block.num : 1;
+  if (block.indent > 0 && curNumList) return curNumList.reference;
+  if (!curNumList || n !== curNumList.expected) {
+    const reference = `numbers-${numberLists.length + 1}`;
+    numberLists.push({ reference, start: n });
+    curNumList = { reference, expected: n + 1 };
+  } else {
+    curNumList.expected = n + 1;
+  }
+  return curNumList.reference;
+}
 
 for (const block of blocks) {
+  if (block.type !== "numbered") curNumList = null;
   switch (block.type) {
     case "heading": {
       const headingRuns = makeRuns(block.text);
@@ -337,6 +372,7 @@ for (const block of blocks) {
       children.push(new Paragraph({
         children: makeRuns(block.text),
         spacing: { before: 80, after: 80 },
+        alignment: bodyAlignment,
       }));
       break;
 
@@ -345,16 +381,20 @@ for (const block of blocks) {
         numbering: { reference: "bullets", level: Math.min(block.indent, 1) },
         children: makeRuns(block.text),
         spacing: { before: 40, after: 40 },
+        alignment: bodyAlignment,
       }));
       break;
 
-    case "numbered":
+    case "numbered": {
+      const numRef = numberingRefFor(block);
       children.push(new Paragraph({
-        numbering: { reference: "numbers", level: Math.min(block.indent, 1) },
+        numbering: { reference: numRef, level: Math.min(block.indent, 1) },
         children: makeRuns(block.text),
         spacing: { before: 40, after: 40 },
+        alignment: bodyAlignment,
       }));
       break;
+    }
 
     case "code": {
       const codeRuns = block.text.split("\n").flatMap((line, idx, arr) => {
@@ -476,13 +516,15 @@ const doc = new Document({
           { level: 1, format: LevelFormat.BULLET, text: "-", alignment: AlignmentType.LEFT,
             style: { paragraph: { indent: { left: 1440, hanging: 360 } } } },
         ] },
-      { reference: "numbers",
+      ...numberLists.map(l => ({
+        reference: l.reference,
         levels: [
-          { level: 0, format: LevelFormat.DECIMAL, text: "%1.", alignment: AlignmentType.LEFT,
+          { level: 0, format: LevelFormat.DECIMAL, text: "%1.", alignment: AlignmentType.LEFT, start: l.start,
             style: { paragraph: { indent: { left: 720, hanging: 360 } } } },
           { level: 1, format: LevelFormat.DECIMAL, text: "%2.", alignment: AlignmentType.LEFT,
             style: { paragraph: { indent: { left: 1440, hanging: 360 } } } },
-        ] },
+        ],
+      })),
     ],
   },
   sections: [{


### PR DESCRIPTION
## What

Three changes to the `md-to-docx` converter, found while exporting a ~400 KB design document (20k+ words, 5 diagrams, ~35 numbered lists).

### Numbered lists shared a single numbering reference (bug)

Every `numbered` paragraph pointed at the one `"numbers"` reference, so Word numbered **all** lists in the document continuously — a list in section 12 kept counting from where section 3 left off.

Each list now gets its own reference and starts at the ordinal written in the markdown: a list opening with `4.` renders as `4.`, not `1.`. As a side effect a list interrupted by an explanatory paragraph now continues instead of restarting.

### Tall images overflowed the page (bug)

`tryLoadImage` clamped width to 576 px but left height unbounded. A tall flowchart came out 9.7 in high on a page with 9 in of printable height and got clipped. Height is now clamped to 780 px with the aspect ratio preserved.

### `--justify` (new, opt-in)

Justified alignment for body paragraphs and list items. Headings and table cells stay left-aligned — justification in narrow table columns produces ragged word spacing.

Off by default, so existing output changes only through the two fixes above.

## Verification

Same 886-block document built both ways:

| | paragraphs with `w:jc val="both"` | numbering definitions |
|---|---|---|
| no flags | 0 | 35 independent lists |
| `--justify` | 624 | 35 independent lists |

Five lists start at 3, 4, 5, 6 and 7 — those are the ones interrupted by a paragraph, now continuing correctly instead of resetting to 1.

## Not included

Mermaid rendering. `md_to_docx.js` does not understand ` ```mermaid ` fences, so diagrams land in the DOCX as code blocks; I pre-rendered them to PNG with mermaid-cli outside the skill. Wiring that in means a mermaid-cli plus headless Chrome dependency — that felt like a maintainer's call rather than something to fold into a bugfix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gg4o3mppRQQFhYcWgqTJNn
